### PR TITLE
App Runnerにデプロイする

### DIFF
--- a/.github/workflows/create-preview-app.yml
+++ b/.github/workflows/create-preview-app.yml
@@ -1,0 +1,27 @@
+# Pull Requestがクローズされたときに、プレビュー環境を削除する
+# Pull Requestにコミットがpushされたときに、プレビュー環境を更新する
+# Pull Requestが作成されたときに、プレビュー環境を作成する
+on:
+  pull_request:
+jobs:
+  create-preview-app:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/aws-service-role/apprunner.amazonaws.com/AWSServiceRoleForAppRunner
+          aws-region: ap-northeast-1
+      # dockerイメージをビルドする。コミットハッシュでいいのかな。pr-123みたいな感じでいいかな。コミットハッシュをつけた方がいいかは分からない。
+      - env:
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+        run: |
+          PR_NUMBER=$(echo $GITHUB_REF | cut -d '/' -f 3)
+          IMAGE_TAG=pr-${PR_NUMBER}
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+      # App Runnerのサービスを作成する

--- a/.github/workflows/create-preview-app.yml
+++ b/.github/workflows/create-preview-app.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/aws-service-role/apprunner.amazonaws.com/AWSServiceRoleForAppRunner
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GitHubActionsRole
           aws-region: ap-northeast-1
       # dockerイメージをビルドする。コミットハッシュでいいのかな。pr-123みたいな感じでいいかな。コミットハッシュをつけた方がいいかは分からない。
       - env:

--- a/.github/workflows/create-preview-app.yml
+++ b/.github/workflows/create-preview-app.yml
@@ -1,6 +1,6 @@
-# Pull Requestがクローズされたときに、プレビュー環境を削除する
-# Pull Requestにコミットがpushされたときに、プレビュー環境を更新する
 # Pull Requestが作成されたときに、プレビュー環境を作成する
+# Pull Requestにコミットがpushされたときに、プレビュー環境を更新する
+# Pull Requestがクローズされたときに、プレビュー環境を削除する
 on:
   pull_request:
     types: [opened,synchronize,reopened]
@@ -35,7 +35,7 @@ jobs:
           docker build -t $IMAGE .
           docker push $IMAGE
           echo "image=$IMAGE" > "$GITHUB_OUTPUT"
-      # Pull Requestが作成、または再オープンされたときにサービスを作成する
+      # Pull Requestが作成または再オープンされたときに、サービスを作成する
       - uses: awslabs/amazon-app-runner-deploy@main
         if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
         with:
@@ -51,4 +51,4 @@ jobs:
       # Pull Requestが更新されたときに、サービスを更新する
       - name: Update preview service
         if: ${{ github.event.action == 'synchronize' }}
-        run: echo 'edited'
+        run: aws apprunner start-deployment --service-arn $(./scripts/get-app-runner-service-arn.sh poc-preview-app-${{ steps.pr-number.outputs.value }})

--- a/.github/workflows/create-preview-app.yml
+++ b/.github/workflows/create-preview-app.yml
@@ -15,8 +15,11 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GitHubActionsRole
           aws-region: ap-northeast-1
+      - name: Authenticate docker CLI
+        run: aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com
       # dockerイメージをビルドする。コミットハッシュでいいのかな。pr-123みたいな感じでいいかな。コミットハッシュをつけた方がいいかは分からない。
-      - env:
+      - name: Build and push docker image
+        env:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         run: |

--- a/.github/workflows/create-preview-app.yml
+++ b/.github/workflows/create-preview-app.yml
@@ -1,6 +1,5 @@
 # Pull Requestが作成されたときに、プレビュー環境を作成する
 # Pull Requestにコミットがpushされたときに、プレビュー環境を更新する
-# Pull Requestがクローズされたときに、プレビュー環境を削除する
 on:
   pull_request:
     types: [opened,synchronize,reopened]

--- a/.github/workflows/create-preview-app.yml
+++ b/.github/workflows/create-preview-app.yml
@@ -3,6 +3,7 @@
 # Pull Requestが作成されたときに、プレビュー環境を作成する
 on:
   pull_request:
+    types: [opened,synchronize,reopened]
 jobs:
   create-preview-app:
     runs-on: ubuntu-22.04
@@ -22,6 +23,7 @@ jobs:
         run: |
           PR_NUMBER=$(echo $GITHUB_REF | cut -d '/' -f 3)
           echo "value=$PR_NUMBER" > "$GITHUB_OUTPUT"
+      # イメージをビルドしてECRにプッシュする
       - name: Build and push docker image
         id: build
         env:
@@ -33,7 +35,9 @@ jobs:
           docker build -t $IMAGE .
           docker push $IMAGE
           echo "image=$IMAGE" > "$GITHUB_OUTPUT"
+      # Pull Requestが作成、または再オープンされたときにサービスを作成する
       - uses: awslabs/amazon-app-runner-deploy@main
+        if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
         with:
           service: poc-preview-app-${{ steps.pr-number.outputs.value }}
           image: ${{ steps.build.outputs.image }}
@@ -44,3 +48,7 @@ jobs:
           port: 3000
           # サービス作成完了まで待つ時間
           wait-for-service-stability-seconds: 600
+      # Pull Requestが更新されたときに、サービスを更新する
+      - name: Update preview service
+        if: ${{ github.event.action == 'synchronize' }}
+        run: echo 'edited'

--- a/.github/workflows/create-preview-app.yml
+++ b/.github/workflows/create-preview-app.yml
@@ -17,14 +17,30 @@ jobs:
           aws-region: ap-northeast-1
       - name: Authenticate docker CLI
         run: aws ecr get-login-password --region ap-northeast-1 | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.ap-northeast-1.amazonaws.com
-      # dockerイメージをビルドする。コミットハッシュでいいのかな。pr-123みたいな感じでいいかな。コミットハッシュをつけた方がいいかは分からない。
+      - name: Set pull request number
+        id: pr-number
+        run: |
+          PR_NUMBER=$(echo $GITHUB_REF | cut -d '/' -f 3)
+          echo "value=$PR_NUMBER" > "$GITHUB_OUTPUT"
       - name: Build and push docker image
+        id: build
         env:
           ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
           ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
         run: |
-          PR_NUMBER=$(echo $GITHUB_REF | cut -d '/' -f 3)
-          IMAGE_TAG=pr-${PR_NUMBER}
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-      # App Runnerのサービスを作成する
+          IMAGE_TAG=pr-${{ steps.pr-number.outputs.value }}
+          IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker build -t $IMAGE .
+          docker push $IMAGE
+          echo "image=$IMAGE" > "$GITHUB_OUTPUT"
+      - uses: awslabs/amazon-app-runner-deploy@main
+        with:
+          service: poc-preview-app-${{ steps.pr-number.outputs.value }}
+          image: ${{ steps.build.outputs.image }}
+          access-role-arn: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/service-role/AppRunnerECRAccessRole
+          region: ap-northeast-1
+          cpu: 0.25
+          memory: 0.5
+          port: 3000
+          # サービス作成完了まで待つ時間
+          wait-for-service-stability-seconds: 600

--- a/.github/workflows/delete-preview-app.yml
+++ b/.github/workflows/delete-preview-app.yml
@@ -1,0 +1,21 @@
+# Pull Requestがクローズされたときに、プレビュー環境を削除する
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  delete-preview-app:
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v3
+      - uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/GitHubActionsRole
+          aws-region: ap-northeast-1
+      # App Runnerのサービスを削除する
+      - name: Delete preview service
+        run: |
+          PR_NUMBER=$(echo $GITHUB_REF | cut -d '/' -f 3)
+          aws apprunner delete-service --service-arn $(./scripts/get-app-runner-service-arn.sh poc-preview-app-${PR_NUMBER})

--- a/scripts/get-app-runner-service-arn.sh
+++ b/scripts/get-app-runner-service-arn.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eu
+
+SERVICE_NAME=$1
+SERVICES=$(aws apprunner list-services --region ap-northeast-1)
+SERVICE_ARN=$(echo $SERVICES | jq --arg SERVICE_NAME "$1" --raw-output '.ServiceSummaryList[] | select(.ServiceName == $SERVICE_NAME) | .ServiceArn')
+
+echo $SERVICE_ARN

--- a/server/src/trpc.ts
+++ b/server/src/trpc.ts
@@ -11,7 +11,7 @@ export const appRouter = t.router({
     return { id: req.input, name: "tekihei2317" };
   }),
   // users: t.procedure.query(() => users),
-  users: t.procedure.query(() => [{ id: 1, name: "tekihei2317" }]),
+  users: t.procedure.query(() => [{ id: 1, name: "tekihei2318" }]),
   createUser: t.procedure
     .input(z.object({ name: z.string() }))
     .mutation((req) => {

--- a/server/src/trpc.ts
+++ b/server/src/trpc.ts
@@ -11,7 +11,7 @@ export const appRouter = t.router({
     return { id: req.input, name: "tekihei2317" };
   }),
   // users: t.procedure.query(() => users),
-  users: t.procedure.query(() => [{ id: 1, name: "tekihei2318" }]),
+  users: t.procedure.query(() => [{ id: 1, name: "tekihei2317" }]),
   createUser: t.procedure
     .input(z.object({ name: z.string() }))
     .mutation((req) => {

--- a/server/src/trpc.ts
+++ b/server/src/trpc.ts
@@ -10,7 +10,8 @@ export const appRouter = t.router({
   user: t.procedure.input(z.string()).query((req) => {
     return { id: req.input, name: "tekihei2317" };
   }),
-  users: t.procedure.query(() => users),
+  // users: t.procedure.query(() => users),
+  users: t.procedure.query(() => [{ id: 1, name: "tekihei2317" }]),
   createUser: t.procedure
     .input(z.object({ name: z.string() }))
     .mutation((req) => {


### PR DESCRIPTION
## 変更点

- Pull Requestを作成したとき（`opened`）に、App Runnerにサービスを作成します。サービス名は`poc-preview-app-<Pull Requestの番号>`です。サービス名は、更新や削除をするときにARNを取得するのに使います。
- Pull Requestを更新したとき（`synchronize`）に、App Runnerのサービスを更新します。`awslabs/amazon-app-runner-deploy`はサービスの設定が更新されるだけで新しいイメージで更新されなかったため、AWS CLIでデプロイを実行するようにしました。
- Pull Requestをクローズした時（`closed`）に、App Runnerのサービスを削除します。

## 参考

- [AWS App RunnerとGitHub Actionsでレビュー環境を構築する - BASEプロダクトチームブログ](https://devblog.thebase.in/entry/2021/12/22/110000)