### PR TITLE
Pull Requestをクローズした時にプレビュー環境を削除する

### DIFF
--- a/.github/workflows/delete-preview-app.yml
+++ b/.github/workflows/delete-preview-app.yml
@@ -17,5 +17,4 @@ jobs:
       # App Runnerのサービスを削除する
       - name: Delete preview service
         run: |
-          PR_NUMBER=$(echo $GITHUB_REF | cut -d '/' -f 3)
-          aws apprunner delete-service --service-arn $(./scripts/get-app-runner-service-arn.sh poc-preview-app-${PR_NUMBER})
+          aws apprunner delete-service --service-arn $(./scripts/get-app-runner-service-arn.sh poc-preview-app-${{ github.event.number }})


### PR DESCRIPTION
closedイベントでは$GITHUB_REFからPull Request番号が取得できないようだったので、github.event.numberに書き換えました。

openedやsynchronizeでは、$GITHUB_REFが`refs/pull/{PR_NUMBER}/merge`というようになっているのですが、close（マージした場合）ではマージ先のブランチになるようです。

pull_requestイベントの場合はgithub.event.numberでPR番号が取得できるようなので、全部それに書き換えてもいいかもしれません。