### PR TITLE
Amplify Hostingのプレビューを有効化する

### DIFF
--- a/scripts/get-app-runner-service-url.sh
+++ b/scripts/get-app-runner-service-url.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eu
+
+SERVICE_NAME=$1
+SERVICES=$(aws apprunner list-services --region ap-northeast-1)
+SERVICE_URL=$(echo $SERVICES | jq --arg SERVICE_NAME "$1" --raw-output '.ServiceSummaryList[] | select(.ServiceName == $SERVICE_NAME) | .ServiceUrl')
+
+echo $SERVICE_URL

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,7 +5,18 @@ import cors from "cors";
 
 const app = express();
 
-app.use(cors({ origin: ["http://localhost:5173", "http://localhost:4173"] }));
+// TODO:
+const previewAppOrigin = /^https:\/\/.+\.amplifyapp\.com$/;
+
+app.use(
+  cors({
+    origin: [
+      "http://localhost:5173",
+      "http://localhost:4173",
+      previewAppOrigin,
+    ],
+  })
+);
 
 app.use(
   "/trpc",


### PR DESCRIPTION
Amplify Hostingのプレビューから、Pull RequestごとのAPIにアクセスしたかったです。しかし、Amplifyのビルドで使うAWS CLIからApp Runnerのサービスにアクセスする方法が分からなかったため（AWS CLIの設定が必要そう）断念しました。

```yaml
version: 1
frontend:
  phases:
    preBuild:
      commands:
        - yarn workspaces focus @sample/web
    build:
      commands:
        - if [ "${AWS_BRANCH}" = "main" ]; then export VITE_API_URL=$API_URL_PRODUCTION; fi;
        # aws cliからApp Runnerにアクセスする権限がないので断念
        # - if [ "${AWS_BRANCH}" != "main" ]; then export VITE_API_URL=https://$(./scripts/get-app-runner-service-url.sh poc-preview-app-${AWS_PULL_REQUEST_ID}); fi;
        - if [ "${AWS_BRANCH}" != "main" ]; then export VITE_API_URL=$API_URL_PREVIEW ; fi
        - echo $VITE_API_URL
        - yarn workspace @sample/web build
  artifacts:
    baseDirectory: web/dist
    files:
      - '**/*'
  cache:
    paths:
      - node_modules/**/*

```